### PR TITLE
Add daily-updated market dashboard web app

### DIFF
--- a/market_dashboard/__init__.py
+++ b/market_dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Market dashboard package."""

--- a/market_dashboard/app.py
+++ b/market_dashboard/app.py
@@ -1,0 +1,37 @@
+"""Flask application serving the market dashboard."""
+
+from __future__ import annotations
+
+from flask import Flask, render_template
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+import pytz
+
+from .data_fetcher import fetch_market_data
+
+app = Flask(__name__)
+market_data = []
+
+
+def update_data() -> None:
+    """Refresh the global market data."""
+    global market_data
+    market_data = fetch_market_data()
+
+
+scheduler = BackgroundScheduler(timezone=pytz.timezone("US/Eastern"))
+scheduler.add_job(update_data, CronTrigger(hour=18, minute=0))
+scheduler.start()
+
+# Initial population
+update_data()
+
+
+@app.route("/")
+def dashboard():
+    """Render the dashboard table."""
+    return render_template("dashboard.html", data=market_data)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/market_dashboard/data_fetcher.py
+++ b/market_dashboard/data_fetcher.py
@@ -1,0 +1,43 @@
+"""Utilities to fetch market data."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Dict
+
+import pandas as pd
+import yfinance as yf
+
+DEFAULT_TICKERS = ["AAPL", "MSFT", "GOOG", "AMZN", "META"]
+
+
+def fetch_market_data(tickers: Iterable[str] | None = None) -> List[Dict[str, float]]:
+    """Return market metrics for the given tickers.
+
+    Parameters
+    ----------
+    tickers: Iterable[str] | None
+        Symbols to fetch. If ``None`` the ``DEFAULT_TICKERS`` are used.
+    """
+    tickers = list(tickers) if tickers is not None else DEFAULT_TICKERS
+    results: List[Dict[str, float]] = []
+    for symbol in tickers:
+        ticker = yf.Ticker(symbol)
+        hist = ticker.history(period="1y")
+        if hist.empty:
+            continue
+        last_close = hist["Close"].iloc[-1]
+        prev_close = hist["Close"].iloc[-2] if len(hist) > 1 else last_close
+        change_pct = ((last_close - prev_close) / prev_close) * 100 if prev_close else 0.0
+        high_52 = hist["Close"].max()
+        low_52 = hist["Close"].min()
+        pct_52_high = (last_close / high_52) * 100 if high_52 else 0.0
+        results.append(
+            {
+                "ticker": symbol,
+                "price": round(float(last_close), 2),
+                "percent_change": round(float(change_pct), 2),
+                "percent_52w_high": round(float(pct_52_high), 2),
+                "52w_range": f"{round(float(low_52),2)} - {round(float(high_52),2)}",
+            }
+        )
+    return results

--- a/market_dashboard/templates/dashboard.html
+++ b/market_dashboard/templates/dashboard.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Market Dashboard</title>
+    <style>
+      table {border-collapse: collapse; width: 80%; margin: auto;}
+      th, td {border: 1px solid #ddd; padding: 8px; text-align: center;}
+      th {background-color: #f2f2f2;}
+    </style>
+  </head>
+  <body>
+    <h1 style="text-align:center;">Market Dashboard</h1>
+    <table>
+      <tr>
+        <th>Ticker</th>
+        <th>Price</th>
+        <th>%&#916;</th>
+        <th>P%</th>
+        <th>52Wk Range</th>
+      </tr>
+      {% for row in data %}
+      <tr>
+        <td>{{ row.ticker }}</td>
+        <td>{{ row.price }}</td>
+        <td>{{ row.percent_change }}</td>
+        <td>{{ row.percent_52w_high }}</td>
+        <td>{{ row['52w_range'] }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,7 @@ requests
 bs4
 lxml
 tqdm
-ScraperFC
+Flask
+APScheduler
+yfinance
+pytz

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setuptools.setup(
     ],
     install_requires = [
         'selenium', 'webdriver-manager', 'pandas', 'numpy', 'datetime',
-        'ipython', 'requests', 'bs4', 'lxml', 'tqdm',
+        'ipython', 'requests', 'bs4', 'lxml', 'tqdm', 'Flask',
+        'APScheduler', 'yfinance', 'pytz'
     ],
     classifiers = [
         'Programming Language :: Python :: 3',

--- a/tests/test_market_dashboard.py
+++ b/tests/test_market_dashboard.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from market_dashboard.data_fetcher import fetch_market_data
+
+
+def test_fetch_market_data_returns_expected_keys():
+    data = fetch_market_data(["AAPL"])
+    assert isinstance(data, list)
+    assert data
+    row = data[0]
+    expected = {"ticker", "price", "percent_change", "percent_52w_high", "52w_range"}
+    assert expected <= row.keys()


### PR DESCRIPTION
## Summary
- add `market_dashboard` Flask app that displays market metrics and refreshes daily after US market close
- schedule data refresh via APScheduler and render simple HTML dashboard
- cover data fetcher with unit test and declare new dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a85c0aaba48327a9602ee5ba938885